### PR TITLE
Feat: Separate RoverTest and VehicleTest

### DIFF
--- a/src/test/java/org/example/RoverTest.java
+++ b/src/test/java/org/example/RoverTest.java
@@ -1,0 +1,30 @@
+package org.example;
+
+import org.junit.jupiter.api.Test;
+
+class RoverTest {
+    private final Rover ROVER = new Rover(RoverType.SURFACE, "0 0");
+
+    @Test
+    public void generateCodeName_ReturnsCodeName_IfRoverIsInstantiated() {
+        String expected = ROVER.getType() + "-" + ROVER.getId();
+        String result = ROVER.getCodeName();
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void setId_Increments_IfRoverIsInstantiated() {
+
+    }
+
+    @Test
+    public void setDirection_SetsDirectionValue_IfNewDirectionIsValid() {
+
+    }
+
+    @Test
+    public void setDirection_ReturnsInvalidInstructionMessage_IfNewDirectionIsInvalid() {
+
+    }
+}

--- a/src/test/java/org/example/VehicleTest.java
+++ b/src/test/java/org/example/VehicleTest.java
@@ -2,21 +2,8 @@ package org.example;
 
 import org.junit.jupiter.api.Test;
 
-class VehicleTest {
+public class VehicleTest {
     private final Rover ROVER = new Rover(RoverType.SURFACE, "0 0");
-
-    @Test
-    public void generateCodeName_ReturnsCodeName_IfRoverIsInstantiated() {
-        String expected = ROVER.getType() + "-" + ROVER.getId();
-        String result = ROVER.getCodeName();
-
-        assertEquals(expected, result);
-    }
-
-    @Test
-    public void setDirection_SetsDirectionValue_IfInputDirectionIsValid() {
-
-    }
 
     @Test
     public void moveTo_ReturnsNewPosition_IfInstructionIsValid() {
@@ -24,7 +11,7 @@ class VehicleTest {
     }
 
     @Test
-    public void moveTo_ReturnsNewPositionAndRemainingInstruction_IfRoverExceedsPlateauLimit() {
+    public void moveTo_ReturnsNewPositionAndRemainingInstruction_IfInstructionExceedsPlateauLimit() {
 
     }
 }


### PR DESCRIPTION
Separated test cases to match Rover inheritance from Vehicle

Changes:
- generateCodeName is now checked as part of RoverTest
- setDirection and moveTo are checked as part of VehicleTest

Reasoning:
All rovers require a codename, but not all vehicles may require a codename so they can implement their own logic as they inherit an ID field.