### PR TITLE
Refactor: Remove Console Messenger Test

### DIFF
--- a/src/test/java/marsmission/marsrover/view/ConsoleMessengerTest.java
+++ b/src/test/java/marsmission/marsrover/view/ConsoleMessengerTest.java
@@ -1,6 +1,0 @@
-package marsmission.marsrover.view;
-
-import static org.junit.jupiter.api.Assertions.*;
-class ConsoleMessengerTest {
-  
-}


### PR DESCRIPTION
Removed test class temporarily to look into testing void methods that contain print statements